### PR TITLE
Default search fields

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.nuix.TieredReport</groupId>
   <artifactId>TieredReport</artifactId>
-  <version>1.23.0</version>
+  <version>1.24.0</version>
 
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -17,6 +17,12 @@
       <version>0.6.44</version>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- <dependency>
       <groupId>com.nuix</groupId>
       <artifactId>nuix-scripting-api</artifactId>
       <version>7.8.7.573</version>
@@ -31,11 +37,6 @@
       <artifactId>aspose-cells</artifactId>
       <version>18.3.0</version>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
+     -->
   </dependencies>
 </project>

--- a/Java/src/main/java/com/nuix/tieredreport/ReportSheetInfo.java
+++ b/Java/src/main/java/com/nuix/tieredreport/ReportSheetInfo.java
@@ -1,6 +1,9 @@
 package com.nuix.tieredreport;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.roaringbitmap.RoaringBitmap;
 
@@ -41,6 +44,23 @@ public class ReportSheetInfo {
 		this.subScopeQuery = subScopeQuery;
 	}
 	
+	private List<String> subScopeDefaultFields = new ArrayList<String>();
+	private Map<String,Object> subScopeSearchSettings = new HashMap<String,Object>();
+	
+	public List<String> getSubScopeDefaultFields() {
+		return subScopeDefaultFields;
+	}
+
+	public void setSubScopeDefaultFields(List<String> subScopeDefaultFields) {
+		this.subScopeDefaultFields = subScopeDefaultFields;
+		subScopeSearchSettings.clear();
+		subScopeSearchSettings.put("defaultFields", subScopeDefaultFields);
+	}
+	
+	public Map<String,Object> getSubScopeSearchSettings(){
+		return subScopeSearchSettings;
+	}
+
 	public boolean getIncludeCategoryHeaderRows(){ return includeCategoryHeaderRows; }
 	public void setIncludeCategoryHeaderRows(boolean value){ includeCategoryHeaderRows = value; }
 	

--- a/Java/src/main/java/com/nuix/tieredreport/TieredReportData.java
+++ b/Java/src/main/java/com/nuix/tieredreport/TieredReportData.java
@@ -320,7 +320,8 @@ public class TieredReportData {
 			if(sheetInfo.getSubScopeQuery() != null && sheetInfo.getSubScopeQuery().trim().isEmpty() != true){
 				// Get items responsive to sub scope query for this sheet
 				fireProgressMessage("  Sheet Sub Scope Query: "+sheetInfo.getSubScopeQuery());
-				Set<Item> subScopeItems = nuixCase.searchUnsorted(sheetInfo.getSubScopeQuery());
+				// Run scope search, using default fields user specified
+				Set<Item> subScopeItems = nuixCase.searchUnsorted(sheetInfo.getSubScopeQuery(),sheetInfo.getSubScopeSearchSettings());
 				fireProgressMessage("  Sheet Sub Scope Items: "+sheetInfo.getSubScopeQuery());
 				// Intersect these items with the overall scope queries items from this case
 				Set<Item> intersected = iutil.intersection(subScopeItems, items);

--- a/Java/src/main/java/com/nuix/tieredreport/aspects/TermsAspect.java
+++ b/Java/src/main/java/com/nuix/tieredreport/aspects/TermsAspect.java
@@ -3,6 +3,7 @@ package com.nuix.tieredreport.aspects;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -22,12 +23,27 @@ import nuix.Utilities;
  */
 public class TermsAspect extends AbstractItemAspect {
 
+	// == List of Terms ==
 	private static List<String> terms = new ArrayList<String>();
 	public static List<String> getTerms(){
 		return terms;
 	}
 	public static void setTerms(List<String> termList){
 		terms = termList;
+	}
+	
+	// == Default search fields for terms ==
+	private static List<String> defaultFields = new ArrayList<String>();
+	private static Map<String,Object> searchSettings = new HashMap<String,Object>();
+	
+	public static List<String> getDefaultFields(){
+		return defaultFields;
+	}
+	
+	public static void setDefaultFields(List<String> fields) {
+		defaultFields = fields;
+		searchSettings.clear();
+		searchSettings.put("defaultFields", fields);
 	}
 	
 	@Override
@@ -39,7 +55,7 @@ public class TermsAspect extends AbstractItemAspect {
 	public void recordValues(Case nuixCase, Utilities utilities, Map<Object, RoaringBitmap> aspectBitmaps, TieredReportData data, Collection<Item> inputItems) {
 		try {
 			for(String term : terms){
-				Set<Item> items = nuixCase.searchUnsorted(term);
+				Set<Item> items = nuixCase.searchUnsorted(term,searchSettings);
 				if(items.size() > 0){
 					data.recordItemsValue(aspectBitmaps, term, utilities.getItemUtility().intersection(items,inputItems));
 				}


### PR DESCRIPTION
- Can now specify the default search fields used for terms which do not explicitly specify a search field.
- Can now specify the default search fields used for per sheet scope query terms which do not explicitly specify a search field.